### PR TITLE
Add support for an ignore option to ignore certain directories

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,13 +11,35 @@ var FindIt = require("findit")
  * @name GitRepos
  * @function
  * @param {String} path The path where to search recursively the git repositories.
+ * @param {Object} options An optional object containing extra options
  * @param {Function} callback The callback function.
  * @return {EventEmitter} The `FindIt` event emitter.
  */
-function GitRepos (path, callback) {
+function GitRepos (path, options, callback) {
     var ev = FindIt(Abs(path));
+  
+    if (arguments.length < 3) {
+      callback = options;
+      options = { };
+    }
+  
+    var ignore;
+    if (typeof options.ignore === 'function') {
+      ignore = options.ignore;
+    }
+    else if (options.ignore instanceof RegExp) {
+      ignore = function(dir) {
+        return options.ignore.test(dir);
+      };
+    }
+    else {
+      return function() { return false; };
+    }
 
     ev.on("directory", function (dir, stat, stop) {
+        if (ignore(dir)) {
+          return stop();
+        }
 
         var cDir = Path.dirname(dir)
           , base = Path.basename(dir)

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,7 @@ function GitRepos (path, options, callback) {
       };
     }
     else {
-      return function() { return false; };
+      ignore = function() { return false; };
     }
 
     ev.on("directory", function (dir, stat, stop) {


### PR DESCRIPTION
Same usage as before should work, but now can also pass in an options object:

```javascript
// Regex ignore
gitRepos('/some/path', { ignore: /node_modules/ }, function(err, dir, stat) {
  // ...
});

// Function ignore
gitRepos('/some/path', { ignore: (dir) => dir.indexOf('node_modules') >= 0 }, function(err, dir, stat) {
  // ...
});
```