### PR TITLE
Speed up looking up Git infos

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,13 +18,13 @@ function GitRepos (path, callback) {
     var ev = FindIt(Abs(path));
 
     ev.on("directory", function (dir, stat, stop) {
-
-        var cDir = Path.dirname(dir)
-          , base = Path.basename(dir)
-          ;
-
-        if (base === ".git") {
-            callback(null, cDir, stat);
+        // Don't traverse into directories that typically won't contain
+        // git repositories, most notably the .git directory itself,
+        // other hidden directories such as .terraform, but also node_modules.
+        if (dir.match(/(\/\..+|node_modules)/)) {
+            if (Path.basename(dir) === ".git") {
+                callback(null, Path.dirname(dir), stat);
+            }
             stop();
         }
     });


### PR DESCRIPTION
By preventing traversal into directories that won't typically contain Git repositories, such as `node_modules`, or hidden directories. Plus, for certain tools (for example Terragrunt), such hidden directories (`.terragrunt-cache`) may contain a Git repo, but in this case you don't want to have that listed either.

I'm a happy user of https://github.com/IonicaBizau/git-unsaved (thank you 🙏) but noticed that we can speed it up with this , and this is where this PR is coming from.

(Alternatively I thought about the ability to specify a "max-depth" option...).